### PR TITLE
Fix login with local account data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ npm run build
 ## 部署
 
 本项目使用Vercel进行部署，后端由远程 API 提供。
+### 默认登录账号
+如果远程 API 无法访问，系统会从 `public/accounts.json` 加载默认账号。
+初始管理员账号密码为 `admin/111`。
+
 
 ## 许可证
 

--- a/public/accounts.json
+++ b/public/accounts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "username": "admin",
+    "password": "111",
+    "groups": ["管理员"]
+  },
+  {
+    "id": 2,
+    "username": "manager",
+    "password": "222",
+    "groups": ["厅管"]
+  }
+]

--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -1,8 +1,14 @@
 const API = '/api/accounts';
 
 export async function getAccounts() {
-  const res = await fetch(API);
-  return res.json();
+  try {
+    const res = await fetch(API);
+    if (!res.ok) throw new Error('network');
+    return await res.json();
+  } catch (err) {
+    const localRes = await fetch('/accounts.json');
+    return localRes.json();
+  }
 }
 
 export async function addAccount(account) {


### PR DESCRIPTION
## Summary
- provide default accounts fallback if `/api/accounts` is unreachable
- add sample `public/accounts.json`
- document default login credentials in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68406414b85483208e36308fe81f5d05