### PR TITLE
Fix group visibility and rename host role

### DIFF
--- a/public/accounts.json
+++ b/public/accounts.json
@@ -10,5 +10,23 @@
     "username": "manager",
     "password": "222",
     "groups": ["厅管"]
+  },
+  {
+    "id": 3,
+    "username": "multi",
+    "password": "333",
+    "groups": ["多厅厅管"]
+  },
+  {
+    "id": 4,
+    "username": "pre",
+    "password": "444",
+    "groups": ["预备厅管"]
+  },
+  {
+    "id": 5,
+    "username": "host",
+    "password": "555",
+    "groups": ["主持"]
   }
 ]

--- a/public/groups.json
+++ b/public/groups.json
@@ -13,7 +13,18 @@
   },
   {
     "id": 2,
-
+    "name": "多厅厅管",
+    "permissions": {
+      "档表管理": { "view": true, "edit": true },
+      "工资管理": { "view": true, "edit": true },
+      "用户编辑": { "view": true, "edit": true },
+      "权限管理": { "view": true, "edit": false },
+      "分厅管理": { "view": true, "edit": true },
+      "团队管理": { "view": true, "edit": true }
+    }
+  },
+  {
+    "id": 3,
     "name": "厅管",
     "permissions": {
       "档表管理": { "view": true, "edit": true },
@@ -25,7 +36,20 @@
     }
   },
   {
-
+    "id": 4,
+    "name": "预备厅管",
+    "permissions": {
+      "档表管理": { "view": true, "edit": true },
+      "工资管理": { "view": true, "edit": true },
+      "用户编辑": { "view": true, "edit": false },
+      "权限管理": { "view": false, "edit": false },
+      "分厅管理": { "view": false, "edit": false },
+      "团队管理": { "view": false, "edit": false }
+    }
+  },
+  {
+    "id": 5,
+    "name": "主持",
     "permissions": {
       "档表管理": { "view": true, "edit": false },
       "工资管理": { "view": true, "edit": false },

--- a/src/services/accountService.js
+++ b/src/services/accountService.js
@@ -10,7 +10,7 @@ export async function getAccounts() {
     if (!res.ok) throw new Error('network');
     return await res.json();
   } catch (err) {
-
+    const localRes = await fetch(LOCAL_ACCOUNTS_URL);
     return localRes.json();
   }
 }

--- a/src/services/groupService.js
+++ b/src/services/groupService.js
@@ -9,6 +9,7 @@ export const PERMISSIONS = [
 
 const API = '/api/groups';
 // Local fallback when the API is unreachable
+const LOCAL_GROUPS_URL = '/groups.json';
 
 
 export async function getGroups() {


### PR DESCRIPTION
## Summary
- add complete groups list and use simplified "主持" label
- provide demo accounts for new groups
- fix fallback handling for accounts and groups services

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840b3b9a5648320bc2db423472fd404